### PR TITLE
Add React PWA with Google Maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# jetlagdc
-A React Web App for the Jet Lag DC trip.
+# Jet Lag DC PWA
+
+This project provides a Progressive Web App (PWA) that displays a Google Map of the Washington DC area with major metro stops labeled.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file in the project root with your Google Maps API key:
+   ```bash
+   REACT_APP_GOOGLE_MAPS_API_KEY=YOUR_API_KEY_HERE
+   ```
+3. Start the development server:
+   ```bash
+   npm start
+   ```
+
+The application is optimized for mobile devices and can be installed as a PWA when deployed.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "jetlagdc",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@react-google-maps/api": "^2.18.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="manifest" href="./manifest.json" />
+    <title>Jet Lag DC Map</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "JetLagDC",
+  "name": "Jet Lag DC PWA",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff"
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,18 @@
+const CACHE_NAME = 'jetlagdc-cache-v1';
+const urlsToCache = ['/', '/index.html'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(urlsToCache);
+    })
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      return response || fetch(event.request);
+    })
+  );
+});

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,4 @@
+.App {
+  text-align: center;
+  height: 100%;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Map from './Map';
+import './App.css';
+
+function App() {
+  return (
+    <div className="App">
+      <Map />
+    </div>
+  );
+}
+
+export default App;

--- a/src/Map.js
+++ b/src/Map.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { GoogleMap, Marker, LoadScript } from '@react-google-maps/api';
+
+const containerStyle = {
+  width: '100%',
+  height: '100%'
+};
+
+const center = {
+  lat: 38.9072,
+  lng: -77.0369
+};
+
+const metroStops = [
+  { name: 'Metro Center', position: { lat: 38.898314, lng: -77.028077 } },
+  { name: 'Gallery Place', position: { lat: 38.8983, lng: -77.0219 } },
+  { name: "L'Enfant Plaza", position: { lat: 38.8848, lng: -77.0219 } },
+  { name: 'Union Station', position: { lat: 38.8971, lng: -77.0064 } },
+  { name: 'Pentagon', position: { lat: 38.869, lng: -77.054 } },
+  { name: 'Smithsonian', position: { lat: 38.888, lng: -77.028 } },
+  { name: 'Farragut West', position: { lat: 38.9013, lng: -77.0398 } },
+  { name: 'Farragut North', position: { lat: 38.9035, lng: -77.0399 } },
+  { name: 'Dupont Circle', position: { lat: 38.9101, lng: -77.043 } },
+  { name: 'Foggy Bottom', position: { lat: 38.9007, lng: -77.0502 } },
+  { name: 'Rosslyn', position: { lat: 38.8961, lng: -77.0717 } },
+  { name: 'Navy Yard', position: { lat: 38.8765, lng: -77.0057 } }
+];
+
+function Map() {
+  return (
+    <LoadScript googleMapsApiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}>
+      <GoogleMap mapContainerStyle={containerStyle} center={center} zoom={12}>
+        {metroStops.map((stop) => (
+          <Marker key={stop.name} position={stop.position} label={stop.name} />
+        ))}
+      </GoogleMap>
+    </LoadScript>
+  );
+}
+
+export default React.memo(Map);

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,10 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+}
+
+#root {
+  height: 100vh;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+import * as serviceWorkerRegistration from './serviceWorkerRegistration';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+
+serviceWorkerRegistration.register();

--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -1,0 +1,9 @@
+export function register() {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker
+        .register('/service-worker.js')
+        .catch((error) => console.error('SW registration failed:', error));
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- initialize React PWA structure
- add Google Maps component with DC metro stops
- include basic service worker for offline support
- document setup steps and placeholder for API key

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68786bba85f8832dbfc752ba321fd79a